### PR TITLE
서강메일 인증 API 구현

### DIFF
--- a/dev-community-backend/build.gradle
+++ b/dev-community-backend/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.session:spring-session-core'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/dev-community-backend/src/main/java/com/letsgo/devcommunity/domain/member/controller/EmailVerificationController.java
+++ b/dev-community-backend/src/main/java/com/letsgo/devcommunity/domain/member/controller/EmailVerificationController.java
@@ -1,0 +1,31 @@
+package com.letsgo.devcommunity.domain.member.controller;
+
+import com.letsgo.devcommunity.domain.member.dto.SendVerificationRequest;
+import com.letsgo.devcommunity.domain.member.dto.VerifyCodeRequest;
+import com.letsgo.devcommunity.domain.member.service.EmailVerificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth/email")
+@RequiredArgsConstructor
+public class EmailVerificationController {
+
+    private final EmailVerificationService verificationService;
+
+    @PostMapping("/verify")
+    public ResponseEntity<Void> sendVerification(@RequestBody SendVerificationRequest request) {
+        verificationService.sendVerificationCode(request.email());
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/check")
+    public ResponseEntity<Void> verifyCode(@RequestBody VerifyCodeRequest request) {
+        verificationService.verifyCode(request.email(), request.code());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/dev-community-backend/src/main/java/com/letsgo/devcommunity/domain/member/dto/SendVerificationRequest.java
+++ b/dev-community-backend/src/main/java/com/letsgo/devcommunity/domain/member/dto/SendVerificationRequest.java
@@ -1,0 +1,4 @@
+package com.letsgo.devcommunity.domain.member.dto;
+
+public record SendVerificationRequest(String email) {
+}

--- a/dev-community-backend/src/main/java/com/letsgo/devcommunity/domain/member/dto/VerifyCodeRequest.java
+++ b/dev-community-backend/src/main/java/com/letsgo/devcommunity/domain/member/dto/VerifyCodeRequest.java
@@ -1,0 +1,4 @@
+package com.letsgo.devcommunity.domain.member.dto;
+
+public record VerifyCodeRequest(String email, String code) {
+}

--- a/dev-community-backend/src/main/java/com/letsgo/devcommunity/domain/member/email/DbEmailVerificationStore.java
+++ b/dev-community-backend/src/main/java/com/letsgo/devcommunity/domain/member/email/DbEmailVerificationStore.java
@@ -1,0 +1,41 @@
+package com.letsgo.devcommunity.domain.member.email;
+
+import com.letsgo.devcommunity.domain.member.entity.EmailVerification;
+import com.letsgo.devcommunity.domain.member.repository.EmailVerificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class DbEmailVerificationStore implements EmailVerificationStore{
+
+    private final EmailVerificationRepository repository;
+
+    @Override
+    public void saveCode(String email, String code, Duration ttl) {
+        EmailVerification verification = repository.findByEmail(email)
+                .map(existing -> {
+                    existing.reissueCode(code, ttl);
+                    return existing;
+                })
+                .orElse(new EmailVerification(email, code, ttl));
+        repository.save(verification);
+    }
+
+    @Override
+    public void verifyCode(String email, String code) {
+        EmailVerification verification = repository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("해당 이메일의 인증 정보가 없습니다."));
+        verification.verify(code);
+        repository.save(verification);
+    }
+
+    @Override
+    public boolean isVerified(String email) {
+        return repository.findByEmail(email)
+                .map(EmailVerification::isVerified)
+                .orElse(false);
+    }
+}

--- a/dev-community-backend/src/main/java/com/letsgo/devcommunity/domain/member/email/EmailVerificationStore.java
+++ b/dev-community-backend/src/main/java/com/letsgo/devcommunity/domain/member/email/EmailVerificationStore.java
@@ -1,0 +1,12 @@
+package com.letsgo.devcommunity.domain.member.email;
+
+import java.time.Duration;
+
+public interface EmailVerificationStore {
+
+    void saveCode(String email, String code, Duration ttl);
+
+    void verifyCode(String email, String code);
+
+    boolean isVerified(String email);
+}

--- a/dev-community-backend/src/main/java/com/letsgo/devcommunity/domain/member/entity/EmailVerification.java
+++ b/dev-community-backend/src/main/java/com/letsgo/devcommunity/domain/member/entity/EmailVerification.java
@@ -1,0 +1,64 @@
+package com.letsgo.devcommunity.domain.member.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailVerification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String code;
+
+    @Column(nullable = false)
+    private boolean isVerified = false;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    public EmailVerification(String email, String code, Duration ttl) {
+        this.email = email;
+        this.code = code;
+        this.expiresAt = LocalDateTime.now().plus(ttl);
+    }
+
+    public void verify(String inputCode) {
+        if (isExpired()) {
+            throw new IllegalStateException("인증번호가 만료되었습니다.");
+        }
+
+        if (!this.code.equals(inputCode)) {
+            throw new IllegalArgumentException("인증번호가 일치하지 않습니다.");
+        }
+
+        this.isVerified = true;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.expiresAt);
+    }
+
+    public void reissueCode(String newCode, Duration ttl) {
+        this.code = newCode;
+        this.expiresAt = LocalDateTime.now().plus(ttl);
+        this.isVerified = false;
+    }
+
+}

--- a/dev-community-backend/src/main/java/com/letsgo/devcommunity/domain/member/repository/EmailVerificationRepository.java
+++ b/dev-community-backend/src/main/java/com/letsgo/devcommunity/domain/member/repository/EmailVerificationRepository.java
@@ -1,0 +1,10 @@
+package com.letsgo.devcommunity.domain.member.repository;
+
+import com.letsgo.devcommunity.domain.member.entity.EmailVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+    Optional<EmailVerification> findByEmail(String email);
+}

--- a/dev-community-backend/src/main/java/com/letsgo/devcommunity/domain/member/service/EmailVerificationService.java
+++ b/dev-community-backend/src/main/java/com/letsgo/devcommunity/domain/member/service/EmailVerificationService.java
@@ -1,0 +1,38 @@
+package com.letsgo.devcommunity.domain.member.service;
+
+import com.letsgo.devcommunity.domain.member.email.EmailVerificationStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService {
+
+    private final EmailVerificationStore store;
+    private final MailService mailService;
+
+    private static final Duration CODE_TTL = Duration.ofMinutes(5);
+
+    public void sendVerificationCode(String email) {
+        String code = generateCode();
+        store.saveCode(email, code, CODE_TTL);
+        mailService.sendVerificationEmail(email, code);
+    }
+
+    public void verifyCode(String email, String inputCode) {
+        store.verifyCode(email, inputCode);
+    }
+
+    public boolean isVerified(String email) {
+        return store.isVerified(email);
+    }
+
+    private String generateCode() {
+        int code = new Random().nextInt(900_000) + 100_000;
+        return String.valueOf(code);
+    }
+
+}

--- a/dev-community-backend/src/main/java/com/letsgo/devcommunity/domain/member/service/MailService.java
+++ b/dev-community-backend/src/main/java/com/letsgo/devcommunity/domain/member/service/MailService.java
@@ -1,0 +1,23 @@
+package com.letsgo.devcommunity.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender mailSender;
+
+    public void sendVerificationEmail(String to, String code) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject("[dev-community] 이메일 인증번호");
+        message.setText("인증번호는 다음과 같습니다: " + code);
+        message.setFrom("knw125@sogang.ac.kr");
+
+        mailSender.send(message);
+    }
+}

--- a/dev-community-backend/src/main/java/com/letsgo/devcommunity/global/config/SecurityConfig.java
+++ b/dev-community-backend/src/main/java/com/letsgo/devcommunity/global/config/SecurityConfig.java
@@ -11,20 +11,17 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
 public class SecurityConfig {
-
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable()) // ✅ 새 방식
-                .formLogin(Customizer.withDefaults()) // 또는 .disable() if not used
-                .httpBasic(Customizer.withDefaults()) // 또는 .disable() if not used
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(new AntPathRequestMatcher("/auth/signup")).permitAll()
-                        .anyRequest().authenticated()
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(authz -> authz
+                        .anyRequest().permitAll()
                 );
 
         return http.build();
     }
+
 
     @Bean
     public PasswordEncoder passwordEncoder() {


### PR DESCRIPTION
## Summary
- 서강메일 인증 API 구현

## Changes
- POST /auth/email/verify 엔드포인트 추가
- -POST /auth/email/check 엔드포인트 추가
- EmailVerification 엔티티, EmailVerificationController, , EmailVerificationRepository,  EmailVerificationService, EmailVerificationStore 인터페이스, DbEmailVerificationStore, MailService, SendVerificationRequest DTO, VerifyCodeRequest DTO 생성
- Spring Security 비활성화

cf) DbEmailVerificationStore는 추후에 RedisVerificationStore로 교체 가능
